### PR TITLE
Add CORS.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "body-parser": "^1.10.0",
     "bookshelf": "^0.7.9",
     "cli-table": "^0.3.1",
+    "cors": "^2.5.2",
     "endpoints": "^0.9.0",
     "express": "^4.10.6",
     "express-routebuilder": "^2.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const express = require('express');
 const bodyParser = require('body-parser');
 const routeBuilder = require('express-routebuilder');
+const cors = require('cors');
 
 const modulePath = path.join(__dirname, 'modules');
 const resources = fs.readdirSync(modulePath);
@@ -12,6 +13,7 @@ const app = express();
 
 const API = require('./classes/api');
 
+app.use(cors());
 app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json({
   type: ['application/json', 'application/vnd.api+json']


### PR DESCRIPTION
Resolves #13 
# 

I'm using this example API to test client-side technologies that interface with JSON API, which I think is a cool use case to support. To do this, we gotta have CORS enabled.
